### PR TITLE
Ignore more environment folder names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 env
+.env
+venv
+.venv
 *.hdf5
 *.mp4
 *.pt


### PR DESCRIPTION
`venv` folder was accidentally briefly pushed to no_mans_land_new, makes this easier to avoid